### PR TITLE
[#27] 상세 페이지 API 구현

### DIFF
--- a/BE/README.md
+++ b/BE/README.md
@@ -12,39 +12,109 @@ http://15.165.190.16/
 
     `http://15.165.190.16/products/main`
     
-### 응답 데이터 
+### 응답 데이터
+- 정상 응답 
 ```
-[
-    {
+{
+    "status": "SUCCESS",
+    "content": [
+        {
+            "hash": "HBDEF",
+            "title": "[미노리키친] 규동 250g",
+            "alt": "[미노리키친] 규동 250g",
+            "description": "일본인의 소울푸드! 한국인도 좋아하는 소고기덮밥",
+            "salePrice": "5,200원",
+            "normalPrice": "6,500원",
+            "image": "http://public.codesquad.kr/jk/storeapp/data/2d3f99a9a35601f4e98837bc4d39b2c8.jpg",
+            "deliveryTypes": [
+                "새벽배송",
+                "전국택배"
+            ],
+            "badges": [
+                "이벤트특가"
+            ]
+        },
+        {
+            "hash": "HDF73",
+            "title": "[빅마마의밥친구] 아삭 고소한 연근고기조림 250g",
+            "alt": "[빅마마의밥친구] 아삭 고소한 연근고기조림 250g",
+            "description": "편식하는 아이도 좋아하는 건강한 연근조림",
+            "salePrice": "0원",
+            "normalPrice": "5,500원",
+            "image": "http://public.codesquad.kr/jk/storeapp/data/7674311a02ba7c88675f3186ddaeef9e.jpg",
+            "deliveryTypes": [
+                "새벽배송",
+                "전국택배"
+            ],
+            "badges": []
+        },
+        ...
+    ]
+}
+```
+
+- 에러 응답
+  - 요청 URL이 잘못된 경우
+  - 상태 코드 : 400 (Bad Request)
+```
+{
+    "status": "ERROR",
+    "content": "API URL 오류"
+}
+```
+
+## 상세 페이지 데이터 요청 API
+### GET `/products/detail/{hash}`
+
+### 필요한 데이터
+- `{hash}`에 상품 hash 값을 넣어주세요.
+  > 예시
+
+    `http://15.165.190.16/products/detail/H72C3`
+    
+### 응답 데이터 
+- 정상 응답 
+```
+{
+    "status": "SUCCESS",
+    "content": {
         "hash": "H72C3",
         "title": "[수하동] 특곰탕 850g",
-        "alt": "[수하동] 특곰탕 850g",
         "description": "100% 한우양지로 끓여낸 70년전통의 서울식곰탕",
         "salePrice": "14,200원",
         "normalPrice": "15,000원",
-        "image": "http://public.codesquad.kr/jk/storeapp/data/d1fccf125f0a78113d0e06cb888f2e74.jpg",
-        "deliveryTypes": [
-            "새벽배송",
-            "전국택배"
+        "point": "142원",
+        "deliveryFee": "2,500원 (40,000원 이상 구매 시 무료)",
+        "deliveryInfo": "서울 경기 새벽배송 / 전국택배 (제주 및 도서산간 불가)[화 · 수 · 목 · 금 · 토] 수령 가능한 상품입니다.",
+        "topImage": "http://public.codesquad.kr/jk/storeapp/data/d1fccf125f0a78113d0e06cb888f2e74.jpg",
+        "thumbImages": [
+            "http://public.codesquad.kr/jk/storeapp/data/d1fccf125f0a78113d0e06cb888f2e74.jpg",
+            "http://public.codesquad.kr/jk/storeapp/data/detail/H0FC6/92f556b605c4a84813070d7214c4f336.jpg",
+            "http://public.codesquad.kr/jk/storeapp/data/detail/H0FC6/538b8ab021c7814aa4af860d94f81287.jpg",
+            "http://public.codesquad.kr/jk/storeapp/data/detail/H0FC6/adaef08ab0680b087096afa0f0070fad.jpg"
         ],
-        "badges": [
-            "이벤트특가"
+        "detailImages": [
+            "http://public.codesquad.kr/jk/storeapp/data/detail/H0FC6/341b8605fa224ec1808c4f169097d170.jpg",
+            "http://public.codesquad.kr/jk/storeapp/data/detail/H0FC6/0228d4cb660a3cca06952917bd024dcb.jpg",
+            "http://public.codesquad.kr/jk/storeapp/data/detail/H0FC6/e027227f61a93b6473e8c4bbd5c3de74.jpg",
+            "http://public.codesquad.kr/jk/storeapp/data/detail/H0FC6/03ac0b09199421bb61727c667c2361f6.jpg",
+            "http://public.codesquad.kr/jk/storeapp/data/detail/H0FC6/cbe4a3e12b7bdba5cf410e0e19dcf1ca.jpg",
+            "http://public.codesquad.kr/jk/storeapp/data/detail/H0FC6/b58fa5791b67db106524b48442cb1c6a.jpg",
+            "http://public.codesquad.kr/jk/storeapp/data/detail/H0FC6/82cfe0332f0e1c927a23b79f1d152430.jpg",
+            "http://public.codesquad.kr/jk/storeapp/data/detail/H0FC6/390ca9ad5a574cbe7f3f6e26871f6690.jpg",
+            "http://public.codesquad.kr/jk/storeapp/data/detail/H0FC6/e113889a6120357c8e6196802a9f155b.jpg",
+            "http://public.codesquad.kr/jk/storeapp/data/detail/H0FC6/967e8e1ef357e9722b796e2bcb09ba3d.jpg"
         ]
-    },
-    {
-        "hash": "HA6EE",
-        "title": "[빅마마의밥친구] 된장찌개 900g",
-        "alt": "[빅마마의밥친구] 된장찌개 900g",
-        "description": "항아리에서 숙성시킨 집된장으로만 맛을내 짜지 않은 된장찌개",
-        "salePrice": "0원",
-        "normalPrice": "10,000원",
-        "image": "http://public.codesquad.kr/jk/storeapp/data/c069bc32cb37727c59e1f0c2839311a0.jpg",
-        "deliveryTypes": [
-            "새벽배송",
-            "전국택배"
-        ],
-        "badges": []
-    },
-    ...
-]
+    }
+}
+```
+
+- 에러 응답
+  - 존재하지 않는 hash를 전달한 경우
+  - 상태 코드 : 404 (Not Found)
+```
+{
+    "status": "ERROR",
+    "content": "존재하지 않는 상품입니다."
+}
 ```

--- a/BE/src/main/java/com/codesquad/sidedish/api/SidedishController.java
+++ b/BE/src/main/java/com/codesquad/sidedish/api/SidedishController.java
@@ -4,7 +4,6 @@ import com.codesquad.sidedish.dao.ProductDAO;
 import com.codesquad.sidedish.dto.DetailDTO;
 import com.codesquad.sidedish.dto.SimpleDTO;
 import com.codesquad.sidedish.entity.Menu;
-import com.codesquad.sidedish.exception.ResourceNotFound;
 import com.codesquad.sidedish.response.ResponseData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,8 +47,6 @@ public class SidedishController {
             processDeliveryInfo(product);
         } catch (DataAccessException e) {
             return new ResponseEntity<>(new ResponseData(ResponseData.STATUS.ERROR, "존재하지 않는 상품입니다."), HttpStatus.NOT_FOUND);
-        } catch (ResourceNotFound e) {
-            return new ResponseEntity<>(new ResponseData(ResponseData.STATUS.ERROR, e.getMessage()), HttpStatus.NOT_FOUND);
         }
         return new ResponseEntity<>(new ResponseData(ResponseData.STATUS.SUCCESS, product), HttpStatus.OK);
     }

--- a/BE/src/main/java/com/codesquad/sidedish/api/SidedishController.java
+++ b/BE/src/main/java/com/codesquad/sidedish/api/SidedishController.java
@@ -1,10 +1,16 @@
 package com.codesquad.sidedish.api;
 
 import com.codesquad.sidedish.dao.ProductDAO;
+import com.codesquad.sidedish.dto.DetailDTO;
 import com.codesquad.sidedish.dto.SimpleDTO;
 import com.codesquad.sidedish.entity.Menu;
+import com.codesquad.sidedish.exception.ResourceNotFound;
+import com.codesquad.sidedish.response.ResponseData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataAccessException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,7 +30,46 @@ public class SidedishController {
     }
 
     @GetMapping("/{menu}")
-    public List<SimpleDTO> showProductsByMenu(@PathVariable String menu) {
-        return productDAO.selectByMenu(Menu.valueOf(menu.toUpperCase()));
+    public ResponseEntity<ResponseData> showProductsByMenu(@PathVariable String menu) {
+        List<SimpleDTO> products = null;
+        try {
+            products = productDAO.selectByMenu(Menu.valueOf(menu.toUpperCase()));
+        } catch (IllegalArgumentException e) {
+            return new ResponseEntity<>(new ResponseData(ResponseData.STATUS.ERROR, "API URL 오류"), HttpStatus.BAD_REQUEST);
+        }
+        return new ResponseEntity<>(new ResponseData(ResponseData.STATUS.SUCCESS, products), HttpStatus.OK);
+    }
+
+    @GetMapping("/detail/{hash}")
+    public ResponseEntity<ResponseData> showDetail(@PathVariable String hash) {
+        DetailDTO product = null;
+        try {
+            product = productDAO.selectDetailByHash(hash);
+            processDeliveryInfo(product);
+        } catch (DataAccessException e) {
+            return new ResponseEntity<>(new ResponseData(ResponseData.STATUS.ERROR, "존재하지 않는 상품입니다."), HttpStatus.NOT_FOUND);
+        } catch (ResourceNotFound e) {
+            return new ResponseEntity<>(new ResponseData(ResponseData.STATUS.ERROR, e.getMessage()), HttpStatus.NOT_FOUND);
+        }
+        return new ResponseEntity<>(new ResponseData(ResponseData.STATUS.SUCCESS, product), HttpStatus.OK);
+    }
+
+    private void processDeliveryInfo(DetailDTO product) {
+        boolean isDoubleType = false;
+        StringBuilder deliveryInfo = new StringBuilder();
+        for (String deliveryType : product.getDeliveryTypes()) {
+            if (isDoubleType)
+                deliveryInfo.append(" / ");
+
+            if (deliveryType.equals("새벽배송")) {
+                deliveryInfo.append("서울 경기 새벽배송");
+                isDoubleType = true;
+            }
+            if (deliveryType.equals("전국택배")) {
+                deliveryInfo.append("전국택배 (제주 및 도서산간 불가)");
+                isDoubleType = true;
+            }
+        }
+        product.setDeliveryInfo(deliveryInfo.append(product.getDeliveryInfo()).append(" 수령 가능한 상품입니다.").toString());
     }
 }

--- a/BE/src/main/java/com/codesquad/sidedish/dao/ProductDAO.java
+++ b/BE/src/main/java/com/codesquad/sidedish/dao/ProductDAO.java
@@ -3,7 +3,6 @@ package com.codesquad.sidedish.dao;
 import com.codesquad.sidedish.dto.DetailDTO;
 import com.codesquad.sidedish.dto.SimpleDTO;
 import com.codesquad.sidedish.entity.Menu;
-import com.codesquad.sidedish.exception.ResourceNotFound;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -41,8 +40,8 @@ public class ProductDAO {
         return products;
     }
 
-    public DetailDTO selectDetailByHash(String hash) throws ResourceNotFound {
-        DetailDTO product = queryFromProductByHash(hash).orElseThrow(ResourceNotFound::new);
+    public DetailDTO selectDetailByHash(String hash) {
+        DetailDTO product = queryFromProductByHash(hash);
         final String sqlForThumbImages = "SELECT ti.url as url" +
                 " FROM thumb_image ti" +
                 " WHERE ti.product = :productId";
@@ -79,14 +78,14 @@ public class ProductDAO {
         );
     }
 
-    private Optional<DetailDTO> queryFromProductByHash(String hash) throws DataAccessException {
+    private DetailDTO queryFromProductByHash(String hash) throws DataAccessException {
         final String sql = "SELECT id, hash, title, description, CONCAT(FORMAT(s_price, 0), '원') as s_price_currency_format, CONCAT(FORMAT(n_price, 0), '원') as n_price_currency_format, s_price, n_price, delivery_fee, delivery_possible, image" +
                 " FROM product" +
                 " WHERE hash = :hash";
         return namedParameterJdbcTemplate.queryForObject(sql,
                 new MapSqlParameterSource("hash", hash),
                 (rs, rowNum) ->
-                        Optional.of( new DetailDTO(
+                        new DetailDTO(
                                 rs.getInt("id"),
                                 rs.getString("hash"),
                                 rs.getString("title"),
@@ -97,7 +96,7 @@ public class ProductDAO {
                                 rs.getString("delivery_fee"),
                                 rs.getString("delivery_possible"),
                                 rs.getString("image")
-                        ))
+                        )
         );
     }
 

--- a/BE/src/main/java/com/codesquad/sidedish/dao/ProductDAO.java
+++ b/BE/src/main/java/com/codesquad/sidedish/dao/ProductDAO.java
@@ -1,14 +1,18 @@
 package com.codesquad.sidedish.dao;
 
+import com.codesquad.sidedish.dto.DetailDTO;
 import com.codesquad.sidedish.dto.SimpleDTO;
 import com.codesquad.sidedish.entity.Menu;
+import com.codesquad.sidedish.exception.ResourceNotFound;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 import javax.sql.DataSource;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public class ProductDAO {
@@ -22,20 +26,37 @@ public class ProductDAO {
 
     public List<SimpleDTO> selectByMenu(Menu menu) {
         List<SimpleDTO> products = queryFromProductByMenu(menu);
-        String sqlForDeliveryTypes = "SELECT d.name as name" +
+        final String sqlForDeliveryTypes = "SELECT d.name as name" +
                 " FROM product_delivery pd" +
                 " LEFT OUTER JOIN delivery d ON pd.delivery = d.id" +
                 " WHERE product = :productId";
-        String sqlForBadges = "SELECT b.name as name" +
+        final String sqlForBadges = "SELECT b.name as name" +
                 " FROM product_badge pb" +
                 " LEFT OUTER JOIN badge b ON pb.badge = b.id" +
                 " WHERE product = :productId";
-
         for (SimpleDTO product : products) {
-            product.setDeliveryTypes(queryByProductId(sqlForDeliveryTypes, product.getId()));
-            product.setBadges(queryByProductId(sqlForBadges, product.getId()));
+            product.setDeliveryTypes(queryByProductId(sqlForDeliveryTypes, product.getId(), "name"));
+            product.setBadges(queryByProductId(sqlForBadges, product.getId(), "name"));
         }
         return products;
+    }
+
+    public DetailDTO selectDetailByHash(String hash) throws ResourceNotFound {
+        DetailDTO product = queryFromProductByHash(hash).orElseThrow(ResourceNotFound::new);
+        final String sqlForThumbImages = "SELECT ti.url as url" +
+                " FROM thumb_image ti" +
+                " WHERE ti.product = :productId";
+        final String sqlForDetailImages = "SELECT di.url as url" +
+                " FROM detail_image di" +
+                " WHERE di.product = :productId";
+        final String sqlForDeliveryTypes = "SELECT d.name as name" +
+                " FROM product_delivery pd" +
+                " LEFT OUTER JOIN delivery d ON pd.delivery = d.id" +
+                " WHERE product = :productId";
+        product.setThumbImages(queryByProductId(sqlForThumbImages, product.getId(), "url"));
+        product.setDetailImages(queryByProductId(sqlForDetailImages, product.getId(), "url"));
+        product.setDeliveryTypes(queryByProductId(sqlForDeliveryTypes, product.getId(), "name"));
+        return product;
     }
 
     private List<SimpleDTO> queryFromProductByMenu(Menu menu) {
@@ -58,11 +79,38 @@ public class ProductDAO {
         );
     }
 
-    private List<String> queryByProductId(String sql, Integer productId) {
+    private Optional<DetailDTO> queryFromProductByHash(String hash) throws DataAccessException {
+        final String sql = "SELECT id, hash, title, description, CONCAT(FORMAT(s_price, 0), '원') as s_price_currency_format, CONCAT(FORMAT(n_price, 0), '원') as n_price_currency_format, s_price, n_price, delivery_fee, delivery_possible, image" +
+                " FROM product" +
+                " WHERE hash = :hash";
+        return namedParameterJdbcTemplate.queryForObject(sql,
+                new MapSqlParameterSource("hash", hash),
+                (rs, rowNum) ->
+                        Optional.of( new DetailDTO(
+                                rs.getInt("id"),
+                                rs.getString("hash"),
+                                rs.getString("title"),
+                                rs.getString("description"),
+                                rs.getString("s_price_currency_format"),
+                                rs.getString("n_price_currency_format"),
+                                getPoint(rs.getInt("s_price"), rs.getInt("n_price")),
+                                rs.getString("delivery_fee"),
+                                rs.getString("delivery_possible"),
+                                rs.getString("image")
+                        ))
+        );
+    }
+
+    private List<String> queryByProductId(String sql, Integer productId, String namedParameter) {
         return namedParameterJdbcTemplate.query(sql,
                 new MapSqlParameterSource("productId", productId),
                 (rs, rowNum) ->
-                        new String(rs.getString("name"))
+                        new String(rs.getString(namedParameter))
         );
+    }
+
+    private String getPoint(int sPrice, int nPrice) {
+        final float POINT_RATIO = 0.01f;
+        return sPrice == 0 ? (int)(nPrice * POINT_RATIO) + "원" : (int)(sPrice * POINT_RATIO) + "원";
     }
 }

--- a/BE/src/main/java/com/codesquad/sidedish/dto/DetailDTO.java
+++ b/BE/src/main/java/com/codesquad/sidedish/dto/DetailDTO.java
@@ -1,8 +1,13 @@
 package com.codesquad.sidedish.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import java.util.List;
 
 public class DetailDTO {
+
+    @JsonIgnore
+    private Integer id;
 
     private String hash;
 
@@ -14,13 +19,99 @@ public class DetailDTO {
 
     private String normalPrice;
 
+    private String point;
+
     private String deliveryFee;
 
-    private String deliveryPossible;
+    private String deliveryInfo;
 
     private String topImage;
 
     private List<String> thumbImages;
 
     private List<String> detailImages;
+
+    @JsonIgnore
+    private List<String> deliveryTypes;
+
+    public DetailDTO(Integer id, String hash, String title, String description, String salePrice, String normalPrice, String point, String deliveryFee, String deliveryInfo, String topImage) {
+        this.id = id;
+        this.hash = hash;
+        this.title = title;
+        this.description = description;
+        this.salePrice = salePrice;
+        this.normalPrice = normalPrice;
+        this.point = point;
+        this.deliveryFee = deliveryFee;
+        this.deliveryInfo = deliveryInfo;
+        this.topImage = topImage;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getHash() {
+        return hash;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getSalePrice() {
+        return salePrice;
+    }
+
+    public String getNormalPrice() {
+        return normalPrice;
+    }
+
+    public String getPoint() {
+        return point;
+    }
+
+    public String getDeliveryFee() {
+        return deliveryFee;
+    }
+
+    public String getDeliveryInfo() {
+        return deliveryInfo;
+    }
+
+    public void setDeliveryInfo(String deliveryInfo) {
+        this.deliveryInfo = deliveryInfo;
+    }
+
+    public String getTopImage() {
+        return topImage;
+    }
+
+    public List<String> getThumbImages() {
+        return thumbImages;
+    }
+
+    public void setThumbImages(List<String> thumbImages) {
+        this.thumbImages = thumbImages;
+    }
+
+    public List<String> getDetailImages() {
+        return detailImages;
+    }
+
+    public void setDetailImages(List<String> detailImages) {
+        this.detailImages = detailImages;
+    }
+
+    public List<String> getDeliveryTypes() {
+        return deliveryTypes;
+    }
+
+    public void setDeliveryTypes(List<String> deliveryTypes) {
+        this.deliveryTypes = deliveryTypes;
+    }
 }

--- a/BE/src/main/java/com/codesquad/sidedish/exception/ResourceNotFound.java
+++ b/BE/src/main/java/com/codesquad/sidedish/exception/ResourceNotFound.java
@@ -1,8 +1,0 @@
-package com.codesquad.sidedish.exception;
-
-public class ResourceNotFound extends RuntimeException {
-
-    public ResourceNotFound() {
-        super("리소스를 찾을 수 없습니다.");
-    }
-}

--- a/BE/src/main/java/com/codesquad/sidedish/exception/ResourceNotFound.java
+++ b/BE/src/main/java/com/codesquad/sidedish/exception/ResourceNotFound.java
@@ -1,0 +1,8 @@
+package com.codesquad.sidedish.exception;
+
+public class ResourceNotFound extends RuntimeException {
+
+    public ResourceNotFound() {
+        super("리소스를 찾을 수 없습니다.");
+    }
+}

--- a/BE/src/main/java/com/codesquad/sidedish/response/ResponseData.java
+++ b/BE/src/main/java/com/codesquad/sidedish/response/ResponseData.java
@@ -1,0 +1,23 @@
+package com.codesquad.sidedish.response;
+
+public class ResponseData {
+
+    public enum STATUS { SUCCESS, ERROR }
+
+    private STATUS status;
+
+    private Object content;
+
+    public ResponseData(STATUS status, Object content) {
+        this.status = status;
+        this.content = content;
+    }
+
+    public String getStatus() {
+        return status.name();
+    }
+
+    public Object getContent() {
+        return content;
+    }
+}

--- a/BE/src/main/resources/application.properties
+++ b/BE/src/main/resources/application.properties
@@ -4,6 +4,10 @@ spring.datasource.url=jdbc:mysql://15.165.190.16:3306/sidedish_db?serverTimezone
 spring.datasource.username=jay
 spring.datasource.password=jay
 
+#spring.datasource.url=jdbc:mysql://15.164.63.83:3306/TEST_SIDEDISH?serverTimezone=UTC&autoReconnect=true
+#spring.datasource.username=springbootUser
+#spring.datasource.password=sBu_1234!
+
 # 스키마 파일
 spring.datasource.initialization-mode=always
 spring.datasource.data=classpath:schema.sql


### PR DESCRIPTION
Closed #27 
- 상세 페이지 API를 구현했습니다.
- API 요청과 응답은 README를 참고해주세요.
- 응답 객체를 통일하기 위해 `ResponseEntity`로 반환하도록 했습니다.
- 응답 객체 클래스는 `ResponseData` 클래스입니다.
- 응답 결과는 `status`에 따라 "SUCCESS"와 "ERROR"로 구분됩니다.
- `content`에 응답에 대한 결과 또는 메세지를 담았습니다.
- deliveryInfo을 가공하는 코드 리팩토링이 필요해보입니다. (나중에...)