### PR TITLE
[#36] Access-Control-Allow-Origin 헤더 관련 Cors 설정

### DIFF
--- a/BE/src/main/java/com/codesquad/sidedish/config/CorsConfig.java
+++ b/BE/src/main/java/com/codesquad/sidedish/config/CorsConfig.java
@@ -1,0 +1,15 @@
+package com.codesquad.sidedish.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("*");
+    }
+}


### PR DESCRIPTION
Closed #36
- 모든 요청 주소에 대해 Origin 허용하도록 설정했습니다.
- 저는 저번에 프록시 서버는 설정하지 않아서 이 코드말고 별도로 작업해야하는게 있는지는 모르겠네요..