### PR TITLE
[#32][#39] 프로퍼티값 암호화, 실행 환경별 설정 파일 구분

### DIFF
--- a/BE/build.gradle
+++ b/BE/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	testImplementation('org.springframework.boot:spring-boot-starter-test') {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
 	}
+	compile group: 'com.github.ulisesbocchio', name: 'jasypt-spring-boot-starter', version: '3.0.2'
 }
 
 test {

--- a/BE/src/main/java/com/codesquad/sidedish/service/OAuthService.java
+++ b/BE/src/main/java/com/codesquad/sidedish/service/OAuthService.java
@@ -3,6 +3,7 @@ package com.codesquad.sidedish.service;
 import com.codesquad.sidedish.entity.OAuthGithubToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -18,8 +19,12 @@ public class OAuthService {
 
     private static final Logger log = LoggerFactory.getLogger(OAuthService.class);
 
-    private final String CLIENTID = "71186054709e9adda0f9";
-    private final String CLIENTSECRET = "c0195e8d988b81aee4d7565da58941dd8e8fcc5a";
+    @Value("${oauth.client.id}")
+    private String CLIENTID;
+
+    @Value("${oauth.client.secret}")
+    private String CLIENTSECRET;
+
     private final String URL = "https://github.com/login/oauth/access_token";
 
     public OAuthGithubToken getAccessToken(String code) {

--- a/BE/src/main/resources/application-local.properties
+++ b/BE/src/main/resources/application-local.properties
@@ -1,0 +1,11 @@
+# DB 정보
+spring.datasource.url=jdbc:mysql://15.165.190.16:3306/sidedish_test_db?serverTimezone=UTC
+spring.datasource.username=ENC(0V6f5mxywsgwQ7YGjlM0gLevqXyA/+qPObF8js75hdVwaphU2mHDWd46LJEI7lKZ)
+spring.datasource.password=ENC(0V6f5mxywsgwQ7YGjlM0gLevqXyA/+qPObF8js75hdVwaphU2mHDWd46LJEI7lKZ)
+
+# 로깅
+logging.level.root=info
+logging.level.sql=debug
+logging.level.com.codesquad.sidedish=debug
+
+jasypt.encryptor.password=${JASYPT_ENCRYPTOR_PASSWORD}

--- a/BE/src/main/resources/application-master.properties
+++ b/BE/src/main/resources/application-master.properties
@@ -1,0 +1,8 @@
+# DB 정보
+spring.datasource.url=jdbc:mysql://15.165.190.16:3306/sidedish_db?serverTimezone=UTC
+spring.datasource.username=ENC(0V6f5mxywsgwQ7YGjlM0gLevqXyA/+qPObF8js75hdVwaphU2mHDWd46LJEI7lKZ)
+spring.datasource.password=ENC(0V6f5mxywsgwQ7YGjlM0gLevqXyA/+qPObF8js75hdVwaphU2mHDWd46LJEI7lKZ)
+
+# 로깅
+logging.level.root=info
+logging.level.web=info

--- a/BE/src/main/resources/application.properties
+++ b/BE/src/main/resources/application.properties
@@ -1,22 +1,11 @@
-# DB 정보
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.url=jdbc:mysql://15.165.190.16:3306/sidedish_db?serverTimezone=UTC
-spring.datasource.username=jay
-spring.datasource.password=jay
-
-#spring.datasource.url=jdbc:mysql://15.164.63.83:3306/TEST_SIDEDISH?serverTimezone=UTC&autoReconnect=true
-#spring.datasource.username=springbootUser
-#spring.datasource.password=sBu_1234!
 
 # 스키마 파일
 spring.datasource.initialization-mode=always
 spring.datasource.data=classpath:schema.sql
 
-# 로깅
-logging.level.root=info
-logging.level.sql=debug
-logging.level.com.codesquad.sidedish=debug
-
 # OAuth Client 정보 암호화
-oauth.client.id=71186054709e9adda0f9
-oauth.client.secret=c0195e8d988b81aee4d7565da58941dd8e8fcc5a
+oauth.client.id=ENC(FoVDWZoQ1CkAJw+VcmSykXI7g84FKn3hXGU3iOH4zaSHCmQQhfnhYqGtI3+WystPOnkMf81YKR4cUAENHd52qw==)
+oauth.client.secret=ENC(H4E5B1VSr/VKv0ivPFunfXcUjC5n4TgP6Ch20EA6kvpveTBybXEFN7r1+kHj7TY1bWAkrOx7tqjcWS1qMbm2LI4xx6+KSFhQ+tq0hTT2uXg=)
+
+spring.profiles.active=local

--- a/BE/src/main/resources/application.properties
+++ b/BE/src/main/resources/application.properties
@@ -16,3 +16,7 @@ spring.datasource.data=classpath:schema.sql
 logging.level.root=info
 logging.level.sql=debug
 logging.level.com.codesquad.sidedish=debug
+
+# OAuth Client 정보 암호화
+oauth.client.id=71186054709e9adda0f9
+oauth.client.secret=c0195e8d988b81aee4d7565da58941dd8e8fcc5a


### PR DESCRIPTION
Closed #32
Closed #39 
- jasypt 라이브러리를 이용하여 OAuth Client Id, secret 정보와 DB 계정 아이디, 비밀번호를 암호화했습니다.
- 배포 시 암호화 비밀번호를 옵션으로 지정하여 실행시켜야 합니다.
- 로컬에서 실행 시 IntelliJ에서 환경 변수를 지정해야 합니다.
- 배포 시 배포용 설정 파일로 실행시키기 위해 master 프로필 옵션을 지정하여 실행시켜야 합니다. 