### PR TITLE
[#42] 이미지 캐싱, 피드백 반영

### DIFF
--- a/iOS/SideDish/SideDish.xcodeproj/project.pbxproj
+++ b/iOS/SideDish/SideDish.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		44129A352454941700A4A6E7 /* ImageFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44129A342454941700A4A6E7 /* ImageFileManager.swift */; };
 		445282FC244EE7BD0077384D /* MenuTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445282FB244EE7BD0077384D /* MenuTableViewCell.swift */; };
 		44528304244F23ED0077384D /* DescriptionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44528303244F23ED0077384D /* DescriptionViewController.swift */; };
 		4460EE7824533F9700EECE13 /* SideDishUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4460EE7724533F9700EECE13 /* SideDishUseCase.swift */; };
@@ -26,6 +27,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		44129A342454941700A4A6E7 /* ImageFileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFileManager.swift; sourceTree = "<group>"; };
 		445282FB244EE7BD0077384D /* MenuTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuTableViewCell.swift; sourceTree = "<group>"; };
 		44528303244F23ED0077384D /* DescriptionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DescriptionViewController.swift; sourceTree = "<group>"; };
 		4460EE7724533F9700EECE13 /* SideDishUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideDishUseCase.swift; sourceTree = "<group>"; };
@@ -125,6 +127,7 @@
 				44DE3E4824506F9E007C5AA8 /* NetworkManager.swift */,
 				4460EE7724533F9700EECE13 /* SideDishUseCase.swift */,
 				44DE3E4A2451D232007C5AA8 /* DataManager.swift */,
+				44129A342454941700A4A6E7 /* ImageFileManager.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -201,6 +204,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				44DE3E4924506F9E007C5AA8 /* NetworkManager.swift in Sources */,
+				44129A352454941700A4A6E7 /* ImageFileManager.swift in Sources */,
 				44DE3E4B2451D232007C5AA8 /* DataManager.swift in Sources */,
 				44A6212C244DA6F8000EC9D3 /* ViewController.swift in Sources */,
 				44528304244F23ED0077384D /* DescriptionViewController.swift in Sources */,

--- a/iOS/SideDish/SideDish/MainScene/MenuTableViewDataSource.swift
+++ b/iOS/SideDish/SideDish/MainScene/MenuTableViewDataSource.swift
@@ -30,14 +30,14 @@ class MenuTableViewDataSource: NSObject, UITableViewDataSource {
         let sideDish = dataManager[indexPath.section][indexPath.row]
         guard cell.hashCode != sideDish.hash else { return cell }
         cell.updateCell(data: sideDish)
-        if let image = ImageFileManager.shared.getSavedImage(name: sideDish.hash) {
+        if let image = ImageFileManager.getSavedImage(name: sideDish.hash) {
             DispatchQueue.main.async {
                 cell.menuImage.image = image
             }
         } else {
             SideDishUseCase.loadImage(url: sideDish.image) { data in
                 guard let image = UIImage(data: data) else { return }
-                ImageFileManager.shared.saveImage(image: image, name: sideDish.hash)
+                ImageFileManager.saveImage(image: image, name: sideDish.hash)
                 NotificationCenter.default.post(name: MenuTableViewDataSource.reloadCell, object: nil, userInfo: [MenuTableViewDataSource.reloadCell: indexPath])
             }
         }

--- a/iOS/SideDish/SideDish/MainScene/MenuTableViewDataSource.swift
+++ b/iOS/SideDish/SideDish/MainScene/MenuTableViewDataSource.swift
@@ -26,8 +26,8 @@ class MenuTableViewDataSource: NSObject, UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: MenuTableViewCell.reuseIdentifier) as? MenuTableViewCell else { return UITableViewCell() }
         let sideDish = dataManager[indexPath.section][indexPath.row]
-        guard cell.sideDish != sideDish else { return cell }
-        cell.sideDish = sideDish
+        guard cell.hashCode != sideDish.hash else { return cell }
+        cell.updateCell(data: sideDish)
         SideDishUseCase.loadImage(url: sideDish.image) { data in
             DispatchQueue.main.async {
                 cell.menuImage.image = UIImage(data: data)

--- a/iOS/SideDish/SideDish/MainScene/MenuTableViewDataSource.swift
+++ b/iOS/SideDish/SideDish/MainScene/MenuTableViewDataSource.swift
@@ -16,7 +16,7 @@ class MenuTableViewDataSource: NSObject, UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return dataManager.sideDishes(at: section).count
+        return dataManager[section].count
     }
     
     func numberOfSections(in tableView: UITableView) -> Int {
@@ -25,7 +25,7 @@ class MenuTableViewDataSource: NSObject, UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: MenuTableViewCell.reuseIdentifier) as? MenuTableViewCell else { return UITableViewCell() }
-        let sideDish = dataManager.sideDishes(at: indexPath.section)[indexPath.row]
+        let sideDish = dataManager[indexPath.section][indexPath.row]
         guard cell.sideDish != sideDish else { return cell }
         cell.sideDish = sideDish
         SideDishUseCase.loadImage(url: sideDish.image) { data in

--- a/iOS/SideDish/SideDish/MainScene/MenuTableViewDataSource.swift
+++ b/iOS/SideDish/SideDish/MainScene/MenuTableViewDataSource.swift
@@ -28,9 +28,18 @@ class MenuTableViewDataSource: NSObject, UITableViewDataSource {
         let sideDish = dataManager[indexPath.section][indexPath.row]
         guard cell.hashCode != sideDish.hash else { return cell }
         cell.updateCell(data: sideDish)
-        SideDishUseCase.loadImage(url: sideDish.image) { data in
+        
+        if let image = ImageFileManager.shared.getSavedImage(name: sideDish.hash) {
             DispatchQueue.main.async {
-                cell.menuImage.image = UIImage(data: data)
+                cell.menuImage.image = image
+            }
+        } else {
+            SideDishUseCase.loadImage(url: sideDish.image) { data in
+                guard let image = UIImage(data: data) else { return }
+                DispatchQueue.main.async {
+                    cell.menuImage.image = image
+                }
+                ImageFileManager.shared.saveImage(image: image, name: sideDish.hash)
             }
         }
         return cell

--- a/iOS/SideDish/SideDish/MainScene/MenuTableViewDataSource.swift
+++ b/iOS/SideDish/SideDish/MainScene/MenuTableViewDataSource.swift
@@ -9,6 +9,8 @@
 import UIKit
 
 class MenuTableViewDataSource: NSObject, UITableViewDataSource {
+    static let reloadCell = NSNotification.Name.init("reloadCell")
+    
     private let dataManager: DataManager
     
     init(dataManager: DataManager) {
@@ -28,7 +30,6 @@ class MenuTableViewDataSource: NSObject, UITableViewDataSource {
         let sideDish = dataManager[indexPath.section][indexPath.row]
         guard cell.hashCode != sideDish.hash else { return cell }
         cell.updateCell(data: sideDish)
-        
         if let image = ImageFileManager.shared.getSavedImage(name: sideDish.hash) {
             DispatchQueue.main.async {
                 cell.menuImage.image = image
@@ -36,10 +37,8 @@ class MenuTableViewDataSource: NSObject, UITableViewDataSource {
         } else {
             SideDishUseCase.loadImage(url: sideDish.image) { data in
                 guard let image = UIImage(data: data) else { return }
-                DispatchQueue.main.async {
-                    cell.menuImage.image = image
-                }
                 ImageFileManager.shared.saveImage(image: image, name: sideDish.hash)
+                NotificationCenter.default.post(name: MenuTableViewDataSource.reloadCell, object: nil, userInfo: [MenuTableViewDataSource.reloadCell: indexPath])
             }
         }
         return cell

--- a/iOS/SideDish/SideDish/MainScene/View/KeywordLabel.swift
+++ b/iOS/SideDish/SideDish/MainScene/View/KeywordLabel.swift
@@ -9,7 +9,12 @@
 import UIKit
 
 class KeywordLabel: UILabel {
+    static var keywordList = [String: UIColor]()
+
     private let padding = UIEdgeInsets(top: 3, left: 3, bottom: 3, right: 3)
+    private let colors = [UIColor.systemIndigo,
+                          UIColor.systemPurple,
+                          UIColor.systemOrange]
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -29,12 +34,11 @@ class KeywordLabel: UILabel {
     }
     
     func setKeyword(_ keyword: String) {
-        let keywordList = ["이벤트특가": UIColor.purple,
-                           "론칭특가": UIColor.purple,
-                           "품절": UIColor.black,
-                           "사은품증정": UIColor.orange]
-        layer.borderColor = keywordList[keyword]?.cgColor
-        backgroundColor = keywordList[keyword]
+        if KeywordLabel.keywordList[keyword] == nil {
+            KeywordLabel.keywordList[keyword] = colors[KeywordLabel.keywordList.count]
+        }
+        layer.borderColor = KeywordLabel.keywordList[keyword]?.cgColor
+        backgroundColor = KeywordLabel.keywordList[keyword]
         text = keyword
         textColor = .white
     }

--- a/iOS/SideDish/SideDish/MainScene/View/MenuTableViewCell.swift
+++ b/iOS/SideDish/SideDish/MainScene/View/MenuTableViewCell.swift
@@ -11,11 +11,7 @@ import UIKit
 class MenuTableViewCell: UITableViewCell {
     static let reuseIdentifier = "menuCell"
     
-    var sideDish: SideDish? {
-        didSet {
-            updateCell()
-        }
-    }
+    private(set) var hashCode = String()
     
     @IBOutlet weak var menuImage: UIImageView! {
         didSet {
@@ -35,25 +31,24 @@ class MenuTableViewCell: UITableViewCell {
         super.init(coder: coder)
     }
     
-    private func configureMenuImage() {
-        menuImage.layer.cornerRadius = menuImage.frame.width / 2
-    }
-    
-    private func updateCell() {
-        guard let sideDish = sideDish else { return }
-        titleLabel.text = sideDish.title
-        descriptionLabel.text = sideDish.description
-        priceLabel.setPrice(sale: sideDish.salePrice, normal: sideDish.normalPrice)
+    func updateCell(data: SideDish) {
+        hashCode = data.hash
+        titleLabel.text = data.title
+        descriptionLabel.text = data.description
+        priceLabel.setPrice(sale: data.salePrice, normal: data.normalPrice)
         eventBadgeStackView.arrangedSubviews.forEach {
             $0.removeFromSuperview()
         }
-        
-        if let badges = sideDish.badges {
+        if let badges = data.badges {
             badges.forEach {
                 let badge = KeywordLabel()
                 badge.setKeyword($0)
                 eventBadgeStackView.addArrangedSubview(badge)
             }
         }
+    }
+    
+    private func configureMenuImage() {
+        menuImage.layer.cornerRadius = menuImage.frame.width / 2
     }
 }

--- a/iOS/SideDish/SideDish/MainScene/ViewController.swift
+++ b/iOS/SideDish/SideDish/MainScene/ViewController.swift
@@ -29,7 +29,7 @@ class ViewController: UIViewController {
     }
     
     private func addObservers() {
-        NotificationCenter.default.addObserver(self, selector: #selector(loadFailed), name: SideDishUseCase.loadFailed, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(errorAlert(_:)), name: SideDishUseCase.loadFailed, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(reloadSection(_:)), name: DataManager.reloadSection, object: nil)
     }
     
@@ -41,8 +41,10 @@ class ViewController: UIViewController {
         }
     }
     
-    @objc private func loadFailed() {
-        let alert = UIAlertController(title: "데이터 로드 실패!", message: "네트워크 연결을 확인해주세요!", preferredStyle: .alert)
+    @objc private func errorAlert(_ notification: NSNotification) {
+        guard let title = notification.userInfo?["title"] as? String,
+            let message = notification.userInfo?["message"] as? String else { return }
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         let cancelAction = UIAlertAction(title: "닫기", style: .cancel, handler: nil)
         alert.addAction(cancelAction)
         DispatchQueue.main.async {

--- a/iOS/SideDish/SideDish/MainScene/ViewController.swift
+++ b/iOS/SideDish/SideDish/MainScene/ViewController.swift
@@ -31,6 +31,7 @@ class ViewController: UIViewController {
     private func addObservers() {
         NotificationCenter.default.addObserver(self, selector: #selector(errorAlert(_:)), name: SideDishUseCase.loadFailed, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(reloadSection(_:)), name: DataManager.reloadSection, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(reloadCell(_:)), name: MenuTableViewDataSource.reloadCell, object: nil)
     }
     
     private func configureUseCase() {
@@ -55,6 +56,13 @@ class ViewController: UIViewController {
     @objc private func reloadSection(_ notification: NSNotification) {
         guard let section = notification.userInfo?[DataManager.reloadSection] as? Int else { return }
         self.menuTableView.reloadSections(IndexSet(integer: section), with: .automatic)
+    }
+    
+    @objc private func reloadCell(_ notification: NSNotification) {
+        guard let indexPath = notification.userInfo?[MenuTableViewDataSource.reloadCell] as? IndexPath else { return }
+        DispatchQueue.main.async {
+            self.menuTableView.reloadRows(at: [indexPath], with: .none)
+        }
     }
 }
 

--- a/iOS/SideDish/SideDish/Model/DataManager.swift
+++ b/iOS/SideDish/SideDish/Model/DataManager.swift
@@ -24,8 +24,10 @@ class DataManager {
         sectionDataList[section] = data
         NotificationCenter.default.post(name: DataManager.reloadSection, object: nil, userInfo: [DataManager.reloadSection: section])
     }
-    
-    func sideDishes(at section: Int) -> [SideDish] {
+}
+
+extension DataManager {
+    subscript(section: Int) -> [SideDish] {
         return sectionDataList[section] ?? []
     }
 }

--- a/iOS/SideDish/SideDish/Model/ImageFileManager.swift
+++ b/iOS/SideDish/SideDish/Model/ImageFileManager.swift
@@ -1,0 +1,28 @@
+//
+//  ImageFileManager.swift
+//  SideDish
+//
+//  Created by TTOzzi on 2020/04/26.
+//  Copyright © 2020 TTOzzi. All rights reserved.
+//
+
+import UIKit
+
+class ImageFileManager {
+    static let shared: ImageFileManager = ImageFileManager()
+    
+    private let imageFileExtension = ".jpeg"
+    
+    func saveImage(image: UIImage, name: String) {
+        guard let data = image.jpegData(compressionQuality: 1),
+            let directory = try? FileManager.default.url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: false) as URL else { return }
+        try? data.write(to: directory.appendingPathComponent(name + imageFileExtension))
+    }
+    
+    func getSavedImage(name: String) -> UIImage? {
+        guard let directory = try? FileManager.default.url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: false) else { return nil }
+        let path = URL(fileURLWithPath: directory.absoluteString).appendingPathComponent(name + imageFileExtension).path
+        let image = UIImage(contentsOfFile: path)
+        return image
+    }
+}

--- a/iOS/SideDish/SideDish/Model/ImageFileManager.swift
+++ b/iOS/SideDish/SideDish/Model/ImageFileManager.swift
@@ -9,17 +9,15 @@
 import UIKit
 
 class ImageFileManager {
-    static let shared: ImageFileManager = ImageFileManager()
+    static let imageFileExtension = ".jpeg"
     
-    private let imageFileExtension = ".jpeg"
-    
-    func saveImage(image: UIImage, name: String) {
+    static func saveImage(image: UIImage, name: String) {
         guard let data = image.jpegData(compressionQuality: 1),
             let directory = try? FileManager.default.url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: false) as URL else { return }
         try? data.write(to: directory.appendingPathComponent(name + imageFileExtension))
     }
     
-    func getSavedImage(name: String) -> UIImage? {
+    static func getSavedImage(name: String) -> UIImage? {
         guard let directory = try? FileManager.default.url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: false) else { return nil }
         let path = URL(fileURLWithPath: directory.absoluteString).appendingPathComponent(name + imageFileExtension).path
         let image = UIImage(contentsOfFile: path)

--- a/iOS/SideDish/SideDish/Model/SideDishUseCase.swift
+++ b/iOS/SideDish/SideDish/Model/SideDishUseCase.swift
@@ -36,7 +36,7 @@ struct SideDishUseCase {
     static func loadList(category: Category, completed: @escaping (Int, [SideDish]) -> ()) {
         NetworkManager.httpRequest(url: serverUrl + category.rawValue, method: .GET, completionHandler: { (data, _, error) in
             guard let data = data else {
-                NotificationCenter.default.post(name: loadFailed, object: nil)
+                NotificationCenter.default.post(name: loadFailed, object: nil, userInfo: ["title":"데이터 로드 실패!","message":"네트워크 연결을 확인해주세요!"])
                 return
             }
             let list = try? JSONDecoder().decode(SideDishData.self, from: data).content
@@ -47,7 +47,7 @@ struct SideDishUseCase {
     static func loadImage(url: String, completed: @escaping (Data) -> ()) {
         NetworkManager.httpRequest(url: url, method: .GET) { (data, response, error) in
             guard let data = data else {
-                NotificationCenter.default.post(name: loadFailed, object: nil)
+                NotificationCenter.default.post(name: loadFailed, object: nil, userInfo: ["title":"이미지 로드 실패!","message":"네트워크 연결을 확인해주세요!"])
                 return
             }
             completed(data)


### PR DESCRIPTION
#### 이미지 캐싱 구현과 #40 의 피드백 반영입니다.

저번 PR 피드백에서 질문을 남겼던 부분을 제외하곤 모두 반영하였습니다.

이미지를 로드할 때 UIImage(data:) 로 로딩하는 방식은 메모리에 올라가기 때문에 조심해야 한다고 하셨는데 url 에서 데이터를 받은 후 처음 한 번은 UIImage(data:) 로 로딩해야할것같은데 맞나요?

그리고
```
한 가지 더, 셀은 재사용하기 때문에 다운로드가 다 된 시점에 셀이 스크롤 돼서 재사용되는 경우가 발생합니다.
이런 경우는 다른 이미지가 표시되는 현상이 생길 수 있습니다. 이건 어떻게 해결할 수 있을지 고민해보세요.
```
이 문제는 이미지가 다운로드 된 시점에 셀의 이미지뷰에 이미지를 넣어줘서 발생한다고 생각합니다.
이를 해결하기 위해 이미지가 다운로드 된 시점에는 캐시 디렉토리에 이미지를 저장만 하고 그 셀을 다시 reload 해줘 셀이 필요한 이미지를 다시 찾도록 해주었습니다.

로직을 순서대로 표현하면 아래와 같습니다.

1. 캐시 디렉토리에 셀 표시에 필요한 이미지가 저장되어 있는지 확인
   * 저장된 이미지가 있다면 불러와 셀의 이미지 뷰에 넣어줌
2. 저장된 이미지가 없다면 url 로 이미지 다운로드 요청을 보냄
3. 이미지가 다운로드 되면 캐시 디렉토리에 저장
4. 셀의 indexPath 와 함께 notification 을 viewController 로 보냄
5. viewController 에서는 해당하는 셀을 reload 해 셀이 다시 필요한 이미지를 찾도록 해줌

셀이 그대로 그 위치에 있다면 저장했던 이미지를 찾아 표시할 것이고 셀의 위치가 바뀌어서 다른 이미지를 필요로 한다면 다시 과정을 반복할 것입니다.