### PR TITLE
[#33] Github Login OAuth2 기능 구현

### DIFF
--- a/BE/build.gradle
+++ b/BE/build.gradle
@@ -33,6 +33,13 @@ dependencies {
 	testImplementation('org.springframework.boot:spring-boot-starter-test') {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
 	}
+	compile 'io.jsonwebtoken:jjwt:0.9.0'
+	compile group: 'org.aspectj', name: 'aspectjrt', version: '1.9.5'
+	compile group: 'org.aspectj', name: 'aspectjweaver', version: '1.9.5'
+	compile group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.0'
+	compile group: 'com.sun.xml.bind', name: 'jaxb-core', version: '2.3.0'
+	compile group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '2.3.0'
+
 	compile group: 'com.github.ulisesbocchio', name: 'jasypt-spring-boot-starter', version: '3.0.2'
 }
 

--- a/BE/src/main/java/com/codesquad/sidedish/api/LoginController.java
+++ b/BE/src/main/java/com/codesquad/sidedish/api/LoginController.java
@@ -1,12 +1,17 @@
 package com.codesquad.sidedish.api;
 
 import com.codesquad.sidedish.entity.OAuthGithubToken;
+import com.codesquad.sidedish.entity.User;
 import com.codesquad.sidedish.service.OAuthService;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.websocket.server.PathParam;
 
@@ -15,19 +20,37 @@ public class LoginController {
 
     private static final Logger log = LoggerFactory.getLogger(SidedishController.class);
 
-    private final OAuthService oAuthService;
+    private final OAuthService oauthService;
 
     public LoginController(OAuthService oAuthService) {
-        this.oAuthService = oAuthService;
+        this.oauthService = oAuthService;
     }
 
     @GetMapping("/login")
     public String OauthTest(@PathParam("code") String code, HttpServletResponse response) {
         log.debug("{}", code);
-        OAuthGithubToken oAuthGithubToken = oAuthService.getAccessToken(code);
+        OAuthGithubToken oAuthGithubToken = oauthService.getAccessToken(code);
         response.setHeader("Authorization", oAuthGithubToken.getAuthorization());
         log.debug("{}", oAuthGithubToken.getAuthorization());
 
         return "/";
+    }
+
+    @PostMapping("/users")
+    public ResponseEntity<String> signIn(HttpServletResponse response, HttpServletRequest request) {
+        String accessToken = request.getHeader("Authorization");
+        log.debug("{}", accessToken);
+        ResponseEntity<JsonNode> jsonNode = oauthService.getUserEmailFromOAuthToken(accessToken);
+        JsonNode body = jsonNode.getBody();
+
+        User newUser = null;
+        for (JsonNode child : body) {
+            if(child.get("primary").asText().equals("true")) {
+                newUser = new User(child.get("email").asText());
+            }
+        }
+        log.debug("{}", newUser.getGithubEmail());
+
+        return ResponseEntity.ok(newUser.getGithubEmail());
     }
 }

--- a/BE/src/main/java/com/codesquad/sidedish/api/LoginController.java
+++ b/BE/src/main/java/com/codesquad/sidedish/api/LoginController.java
@@ -30,10 +30,8 @@ public class LoginController {
     public ResponseEntity<String> OauthTest(@PathParam("code") String code, HttpServletResponse response) {
         log.debug("{}", code);
         OAuthGithubToken oAuthGithubToken = oauthService.getAccessToken(code);
-//        response.setHeader("Authorization", oAuthGithubToken.getAuthorization());
         log.debug("{}", oAuthGithubToken.getAuthorization());
         String accessToken = oAuthGithubToken.getAuthorization();
-        log.debug("{}", accessToken);
 
         ResponseEntity<JsonNode> jsonNode = oauthService.getUserEmailFromOAuthToken(accessToken);
         JsonNode body = jsonNode.getBody();
@@ -49,21 +47,4 @@ public class LoginController {
         return ResponseEntity.ok("Login Success");
     }
 
-    @PostMapping("/users")
-    public ResponseEntity<String> signIn(HttpServletResponse response, HttpServletRequest request) {
-        String accessToken = request.getHeader("Authorization");
-        log.debug("{}", accessToken);
-        ResponseEntity<JsonNode> jsonNode = oauthService.getUserEmailFromOAuthToken(accessToken);
-        JsonNode body = jsonNode.getBody();
-
-        User newUser = null;
-        for (JsonNode child : body) {
-            if(child.get("primary").asText().equals("true")) {
-                newUser = new User(child.get("email").asText());
-            }
-        }
-        log.debug("{}", newUser.getGithubEmail());
-
-        return ResponseEntity.ok(newUser.getGithubEmail());
-    }
 }

--- a/BE/src/main/java/com/codesquad/sidedish/api/LoginController.java
+++ b/BE/src/main/java/com/codesquad/sidedish/api/LoginController.java
@@ -27,13 +27,26 @@ public class LoginController {
     }
 
     @GetMapping("/login")
-    public String OauthTest(@PathParam("code") String code, HttpServletResponse response) {
+    public ResponseEntity<String> OauthTest(@PathParam("code") String code, HttpServletResponse response) {
         log.debug("{}", code);
         OAuthGithubToken oAuthGithubToken = oauthService.getAccessToken(code);
-        response.setHeader("Authorization", oAuthGithubToken.getAuthorization());
+//        response.setHeader("Authorization", oAuthGithubToken.getAuthorization());
         log.debug("{}", oAuthGithubToken.getAuthorization());
+        String accessToken = oAuthGithubToken.getAuthorization();
+        log.debug("{}", accessToken);
 
-        return "/";
+        ResponseEntity<JsonNode> jsonNode = oauthService.getUserEmailFromOAuthToken(accessToken);
+        JsonNode body = jsonNode.getBody();
+
+        User newUser = null;
+        for (JsonNode child : body) {
+            if(child.get("primary").asText().equals("true")) {
+                newUser = new User(child.get("email").asText());
+            }
+        }
+        log.debug("{}", newUser.getGithubEmail());
+
+        return ResponseEntity.ok("Login Success");
     }
 
     @PostMapping("/users")

--- a/BE/src/main/java/com/codesquad/sidedish/api/LoginController.java
+++ b/BE/src/main/java/com/codesquad/sidedish/api/LoginController.java
@@ -4,14 +4,13 @@ import com.codesquad.sidedish.entity.OAuthGithubToken;
 import com.codesquad.sidedish.service.OAuthService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.websocket.server.PathParam;
 
-@RestController
+@Controller
 public class LoginController {
 
     private static final Logger log = LoggerFactory.getLogger(SidedishController.class);
@@ -22,13 +21,13 @@ public class LoginController {
         this.oAuthService = oAuthService;
     }
 
-    @GetMapping("/login/oauth2/code/github")
-    public ResponseEntity<String> OauthTest(@PathParam("code") String code, HttpServletResponse response) {
+    @GetMapping("/login")
+    public String OauthTest(@PathParam("code") String code, HttpServletResponse response) {
         log.debug("{}", code);
         OAuthGithubToken oAuthGithubToken = oAuthService.getAccessToken(code);
         response.setHeader("Authorization", oAuthGithubToken.getAuthorization());
         log.debug("{}", oAuthGithubToken.getAuthorization());
 
-        return ResponseEntity.ok("Login Success");
+        return "/";
     }
 }

--- a/BE/src/main/java/com/codesquad/sidedish/api/LoginController.java
+++ b/BE/src/main/java/com/codesquad/sidedish/api/LoginController.java
@@ -2,18 +2,21 @@ package com.codesquad.sidedish.api;
 
 import com.codesquad.sidedish.entity.OAuthGithubToken;
 import com.codesquad.sidedish.entity.User;
+import com.codesquad.sidedish.response.ResponseData;
+import com.codesquad.sidedish.security.JwtToken;
 import com.codesquad.sidedish.service.OAuthService;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 
-import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 import javax.websocket.server.PathParam;
+import java.io.IOException;
 
 @Controller
 public class LoginController {
@@ -21,13 +24,14 @@ public class LoginController {
     private static final Logger log = LoggerFactory.getLogger(SidedishController.class);
 
     private final OAuthService oauthService;
+    private JwtToken jwtToken = new JwtToken();
 
     public LoginController(OAuthService oAuthService) {
         this.oauthService = oAuthService;
     }
 
     @GetMapping("/login")
-    public ResponseEntity<String> OauthTest(@PathParam("code") String code, HttpServletResponse response) {
+    public String OauthTest(@PathParam("code") String code, HttpServletResponse response) throws IOException {
         log.debug("{}", code);
         OAuthGithubToken oAuthGithubToken = oauthService.getAccessToken(code);
         log.debug("{}", oAuthGithubToken.getAuthorization());
@@ -44,7 +48,11 @@ public class LoginController {
         }
         log.debug("{}", newUser.getGithubEmail());
 
-        return ResponseEntity.ok("Login Success");
+        String jwt = jwtToken.JwtTokenMaker(newUser);
+        log.debug("{}", jwt);
+
+        response.addCookie(new Cookie("Authorization", jwt));
+        return "redirect:/";
     }
 
 }

--- a/BE/src/main/java/com/codesquad/sidedish/api/LoginController.java
+++ b/BE/src/main/java/com/codesquad/sidedish/api/LoginController.java
@@ -2,17 +2,14 @@ package com.codesquad.sidedish.api;
 
 import com.codesquad.sidedish.entity.OAuthGithubToken;
 import com.codesquad.sidedish.entity.User;
-import com.codesquad.sidedish.response.ResponseData;
 import com.codesquad.sidedish.security.JwtToken;
 import com.codesquad.sidedish.service.OAuthService;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 import javax.websocket.server.PathParam;
@@ -42,7 +39,7 @@ public class LoginController {
 
         User newUser = null;
         for (JsonNode child : body) {
-            if(child.get("primary").asText().equals("true")) {
+            if (child.get("primary").asText().equals("true")) {
                 newUser = new User(child.get("email").asText());
             }
         }

--- a/BE/src/main/java/com/codesquad/sidedish/entity/User.java
+++ b/BE/src/main/java/com/codesquad/sidedish/entity/User.java
@@ -1,0 +1,31 @@
+package com.codesquad.sidedish.entity;
+
+import org.springframework.data.annotation.Id;
+
+public class User {
+
+    @Id
+    private Long id;
+
+    private String githubEmail;
+
+    public User(String githubEmail) {
+        this.githubEmail = githubEmail;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getGithubEmail() {
+        return githubEmail;
+    }
+
+    public void setGithubEmail(String githubEmail) {
+        this.githubEmail = githubEmail;
+    }
+}

--- a/BE/src/main/java/com/codesquad/sidedish/security/JwtToken.java
+++ b/BE/src/main/java/com/codesquad/sidedish/security/JwtToken.java
@@ -1,0 +1,44 @@
+package com.codesquad.sidedish.security;
+
+import com.codesquad.sidedish.entity.User;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+
+import javax.crypto.spec.SecretKeySpec;
+import javax.xml.bind.DatatypeConverter;
+import java.security.Key;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+public class JwtToken {
+
+    public String JwtTokenMaker(User user) {
+        String secretKey = "sidedish";
+        SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+        String githubEmail = user.getGithubEmail();
+
+        Long expiredTime = 1000 * 60 * 60 * 24L;
+        Date now = new Date();
+        now.setTime(now.getTime()+expiredTime);
+
+        byte[] apiKeySecretBytes = DatatypeConverter.parseBase64Binary(secretKey);
+        Key key = new SecretKeySpec(apiKeySecretBytes, signatureAlgorithm.getJcaName());
+
+        Map<String,Object> header = new HashMap<>();
+        Map<String,Object> payload = new HashMap<>();
+
+        header.put("typ","JWT");
+        header.put("alg","HS256");
+
+        payload.put("sub","userInfo");
+        payload.put("exp",now);
+        payload.put("githubEmail",githubEmail);
+
+        return Jwts.builder()
+                .setHeader(header)
+                .setClaims(payload)
+                .signWith(signatureAlgorithm,key)
+                .compact();
+    }
+}

--- a/BE/src/main/java/com/codesquad/sidedish/service/OAuthService.java
+++ b/BE/src/main/java/com/codesquad/sidedish/service/OAuthService.java
@@ -1,10 +1,13 @@
 package com.codesquad.sidedish.service;
 
 import com.codesquad.sidedish.entity.OAuthGithubToken;
+import com.codesquad.sidedish.entity.User;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
@@ -25,7 +28,8 @@ public class OAuthService {
     @Value("${oauth.client.secret}")
     private String CLIENTSECRET;
 
-    private final String URL = "https://github.com/login/oauth/access_token";
+    private final String OAUTHURL = "https://github.com/login/oauth/access_token";
+    private final String EMAILAPIURL = "https://api.github.com/user/emails";
 
     public OAuthGithubToken getAccessToken(String code) {
         MultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
@@ -41,13 +45,23 @@ public class OAuthService {
 
         HttpEntity<?> request = new HttpEntity<>(requestPayload, headers);
 
-        ResponseEntity<?> response = new RestTemplate().postForEntity(URL, request, OAuthGithubToken.class);
+        ResponseEntity<?> response = new RestTemplate().postForEntity(OAUTHURL, request, OAuthGithubToken.class);
         return (OAuthGithubToken) response.getBody();
     }
 
-    public String getUserEmailFromOAuthToken(String code) {
+    public ResponseEntity<JsonNode> getUserEmailFromOAuthToken(String accessToken) {
+        MultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
+        Map<String, String> header = new HashMap<>();
+        header.put("Authorization", accessToken);
+        header.put("Content-Type", "application/json");
 
-        return null;
+        headers.setAll(header);
+
+        HttpEntity<?> request = new HttpEntity<>(headers);
+
+        ResponseEntity<JsonNode> response = new RestTemplate().exchange(EMAILAPIURL, HttpMethod.GET, request, JsonNode.class);
+
+        return response;
     }
 
 }

--- a/BE/src/main/java/com/codesquad/sidedish/service/OAuthService.java
+++ b/BE/src/main/java/com/codesquad/sidedish/service/OAuthService.java
@@ -45,4 +45,9 @@ public class OAuthService {
         return (OAuthGithubToken) response.getBody();
     }
 
+    public String getUserEmailFromOAuthToken(String code) {
+
+        return null;
+    }
+
 }

--- a/BE/src/main/java/com/codesquad/sidedish/service/OAuthService.java
+++ b/BE/src/main/java/com/codesquad/sidedish/service/OAuthService.java
@@ -1,7 +1,6 @@
 package com.codesquad.sidedish.service;
 
 import com.codesquad.sidedish.entity.OAuthGithubToken;
-import com.codesquad.sidedish.entity.User;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/BE/src/main/resources/static/index.html
+++ b/BE/src/main/resources/static/index.html
@@ -7,8 +7,17 @@ OAuth2
 <h1>Login</h1>
 <div class="container unauthenticated">
     <div>
+<<<<<<< HEAD
         Github : <a href="https://github.com/login/oauth/authorize?client_id=71186054709e9adda0f9&scope=user:email&redirect_uri=http://15.164.63.83:8080/login/oauth2/code/github">Click</a>
+=======
+        Github : <a href="https://github.com/login/oauth/authorize?client_id=d24c87e3d87d17bec234&scope=user:email&redirect_uri=http://localhost:8080/login">Click</a>
+>>>>>>> [#33] Feat: 회원가입 버튼 요청 처리를 위한 method 생성
     </div>
+    <form name="login" method="post" action="/login">
+        <div>
+            Sign Up : <button type="submit" class="btn btn-success clearfix pull-right">Click</button>
+        </div>
+    </form>
 </div>
 <div class="container"></div>
 </body>

--- a/BE/src/main/resources/static/index.html
+++ b/BE/src/main/resources/static/index.html
@@ -7,11 +7,7 @@ OAuth2
 <h1>Login</h1>
 <div class="container">
     <div>
-<<<<<<< HEAD
-        Github : <a href="https://github.com/login/oauth/authorize?client_id=71186054709e9adda0f9&scope=user:email&redirect_uri=http://15.164.63.83:8080/login/oauth2/code/github">Click</a>
-=======
-        Github : <a href="https://github.com/login/oauth/authorize?client_id=d24c87e3d87d17bec234&scope=user:email&redirect_uri=http://localhost:8080/login">Click</a>
->>>>>>> [#33] Feat: 회원가입 버튼 요청 처리를 위한 method 생성
+        Github : <a href="https://github.com/login/oauth/authorize?client_id=71186054709e9adda0f9&scope=user:email&redirect_uri=http://15.164.63.83:8080/login">Click</a>
     </div>
 </div>
 

--- a/BE/src/main/resources/static/index.html
+++ b/BE/src/main/resources/static/index.html
@@ -5,7 +5,7 @@ OAuth2
 </head>
 <body>
 <h1>Login</h1>
-<div class="container unauthenticated">
+<div class="container">
     <div>
 <<<<<<< HEAD
         Github : <a href="https://github.com/login/oauth/authorize?client_id=71186054709e9adda0f9&scope=user:email&redirect_uri=http://15.164.63.83:8080/login/oauth2/code/github">Click</a>
@@ -13,12 +13,12 @@ OAuth2
         Github : <a href="https://github.com/login/oauth/authorize?client_id=d24c87e3d87d17bec234&scope=user:email&redirect_uri=http://localhost:8080/login">Click</a>
 >>>>>>> [#33] Feat: 회원가입 버튼 요청 처리를 위한 method 생성
     </div>
-    <form name="login" method="post" action="/login">
+    <form name="login" method="POST" action="/users">
         <div>
             Sign Up : <button type="submit" class="btn btn-success clearfix pull-right">Click</button>
         </div>
     </form>
 </div>
-<div class="container"></div>
+
 </body>
 </html>

--- a/BE/src/main/resources/static/index.html
+++ b/BE/src/main/resources/static/index.html
@@ -13,11 +13,6 @@ OAuth2
         Github : <a href="https://github.com/login/oauth/authorize?client_id=d24c87e3d87d17bec234&scope=user:email&redirect_uri=http://localhost:8080/login">Click</a>
 >>>>>>> [#33] Feat: 회원가입 버튼 요청 처리를 위한 method 생성
     </div>
-    <form name="login" method="POST" action="/users">
-        <div>
-            Sign Up : <button type="submit" class="btn btn-success clearfix pull-right">Click</button>
-        </div>
-    </form>
 </div>
 
 </body>


### PR DESCRIPTION
- 시나리오
     - 사용자가 Github Login 버튼 클릭
     - Github에서 code와 함께 callback URI로 돌려줌
     - callback URI를 바로 controller에서 받음
     - code, client_id, client_secret 세 가지를 담아 Github에 요청
     - Github에서 확인 후 Access Token을 우리 서버로 발급 해줌
     - Access Token을 이용해 사용자의 email 주소를 요청
     - 해당 email로 JWT토큰을 우리 서버에서 발급
     - JWT토큰을 쿠키에 담아 메인 화면으로 리다이렉팅

- 너무 한 곳에서 모든 로직을 처리 하다 보니 리팩토링 필요